### PR TITLE
bug when calling new js.Proxy(js.context.Array)

### DIFF
--- a/lib/js.dart
+++ b/lib/js.dart
@@ -750,8 +750,21 @@ class Proxy {
    * JavaScript [constructor].  The arguments should be either
    * primitive values, DOM elements, or Proxies.
    */
-  factory Proxy(constructor, [arg1, arg2, arg3, arg4]) =>
-      new Proxy.withArgList(constructor, [arg1, arg2, arg3, arg4]);
+  factory Proxy(constructor, [arg1, arg2, arg3, arg4]) {
+      var arguments;
+      if (?arg4) {
+        arguments = [arg1, arg2, arg3, arg4];
+      } else if (?arg3) {
+        arguments = [arg1, arg2, arg3];
+      } else if (?arg2) {
+        arguments = [arg1, arg2];
+      } else if (?arg1) {
+        arguments = [arg1];
+      } else {
+        arguments = [];
+      }
+      return new Proxy.withArgList(constructor, arguments);
+  }
 
   /**
    * Constructs a [Proxy] to a new JavaScript object by invoking a (proxy to a)

--- a/test/browser_tests.dart
+++ b/test/browser_tests.dart
@@ -25,6 +25,32 @@ main() {
     });
   });
 
+
+  test('instanciation of Array', () {
+    js.scoped(() {
+      final a = new js.Proxy(js.context.Array);
+      expect(a, isNotNull);
+      expect(a.length, equals(0));
+
+      a.push("value 1");
+      expect(a.length, equals(1));
+      expect(a[0], equals("value 1"));
+
+      a.pop();
+      expect(a.length, equals(0));
+    });
+  });
+
+  test('instanciation of Object', () {
+    js.scoped(() {
+      final a = new js.Proxy(js.context.Object);
+      expect(a, isNotNull);
+
+      a.attr = "value";
+      expect(a.attr, equals("value"));
+    });
+  });
+
   test('write global field', () {
     js.scoped(() {
       js.context.y = 42;


### PR DESCRIPTION
When calling `new js.Proxy(js.context.Array)` a `[null, null, null, null]` was returned.
