### PR TITLE
updated pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,4 +4,6 @@ homepage: https://github.com/dart-lang/js-interop
 description: Access JavaScript from Dart.
 version: 0.0.12
 dependencies:
-  unittest: any
+  unittest: 
+    version: any
+    sdk: unittest


### PR DESCRIPTION
# Problem 1

There's a problem with the follwing pubspec dependencies

``` yaml
dependencies:
  unittest:
    sdk: unittest

  js:
    hosted: js
```

Problem

```
Resolving dependencies...
Package 'unittest' is depended on from both sources 'sdk' and 'hosted'.
```
# Problem 2

There's a problem with the follwing pubspec dependencies

``` yaml
dependencies:
  unittest:
    sdk: unittest

  js: 
    git: git://github.com/dart-lang/js-interop.git
```

Problem

```
Resolving dependencies...
Package 'unittest' is depended on from both sources 'sdk' and 'hosted'.
```
# Solution

Change the dependencies in your `pubspec.yaml`, see pull request.

pub can resolve the following dependencies: 

``` yaml
dependencies:
  unittest:
    sdk: unittest

  js: 
    git: git://github.com/dart-lang/js-interop.git
```
