### PR TITLE
New Proxy.callMethod for dynamically named function calls

### DIFF
--- a/lib/js.dart
+++ b/lib/js.dart
@@ -905,7 +905,8 @@ class Proxy {
          _jsPortEquals.callSync([_serialize(this), _serialize(other)]));
 
   // Call a method with the given name & arguments on this object.
-  // TODO(sasha): integrate this with a wrapped return from the [] operator, i.e. x[member](args). 
+  // TODO(sasha): Integrate this with a wrapped return from the [] operator,
+  // e.g. x[member](args).
   callMethod(String member, List args) {
     return _forward(this, member, 'method', args);
   }

--- a/test/browser_tests.dart
+++ b/test/browser_tests.dart
@@ -116,6 +116,13 @@ main() {
     });
   });
 
+  test('call JS function by dynamic name', () {
+    js.scoped(() {
+      expect(js.context.callMethod('razzle', []), equals(42));
+      expect(() => js.context.callMethod('dazzle', []), throwsA(isNoSuchMethodError));
+    });
+  });
+
   test('allocate JS object', () {
     js.scoped(() {
       var foo = new js.Proxy(js.context.Foo, 42);


### PR DESCRIPTION
I added the callMethod function to Proxy objects, as there is currently no way of calling a function with an arbitrary name on Javascript objects.

For example, the following would work:

```
js.context.console.log('hi!');
```

But these examples would not work:

```
js.context.console['log']('hi!');
```

```
var x = js.context.console.log
x('hi!');
```

This is because the Function object detaches from its parent object when it is called. I believe this is caused from this TODO: [master/lib/dart_interop.js#L148](https://github.com/dart-lang/js-interop/blob/master/lib/dart_interop.js#L148)

The callMethod function is a temporary solution that allows chaining the [] and call operators. In future, we can return a wrapped object from [] that has an appropriate call method which remembers its parent.

Thanks,

Sasha
