### PR TITLE
DartProxy not deserialized as Dart object

### DIFF
--- a/test/browser_tests.dart
+++ b/test/browser_tests.dart
@@ -384,4 +384,12 @@ main() {
       expect(js.context.Bar.foo, "property_value");
     });
   });
+
+  test('retrieve same dart Object', () {
+    js.scoped(() {
+      final date = new Date.now();
+      js.context.dartDate = date;
+      expect(js.context.dartDate, equals(date));
+    });
+  });
 }


### PR DESCRIPTION
When I get back a dart object that has been put in js code, I get an `Instance of 'Proxy'` instead of the local dart object. For instance the following test fails :

``` dart
test('retrieve same dart Object', () {
  js.scoped(() {
    final date = new Date.now();
    js.context.dartDate = date;
    expect(js.context.dartDate, equals(date));
  });
});
```

I tried to dive into the code and fix that, but I did not succeed... The problem seems to be in :

``` dart
deserializeObject(message) {
  var id = message[1];
  var port = message[2];
  if (port == _proxiedObjectTable.sendPort) {
    // Local object.
    return _proxiedObjectTable.get(id);
  } else {
    // Remote object.
    return new Proxy._internal(port, id);
  }
}
```

For the above test, `port` and `_proxiedObjectTable.sendPort` display `Instance of '_LocalSendPortSync@0x3918afae'` in debugger but `port == _proxiedObjectTable.sendPort` is evaluated as `false` and I don't know why.
