### PR TITLE
Fetching non-existing properties return null

### DIFF
--- a/lib/js.dart
+++ b/lib/js.dart
@@ -481,10 +481,10 @@ final _JS_BOOTSTRAP = r"""
       // Dummy Type with correct constructor.
       var Type = function(){};
       Type.prototype = constructor.prototype;
-  
+
       // Create a new instance
       var instance = new Type();
-  
+
       // Call the original constructor.
       ret = constructor.apply(instance, args);
       ret = Object(ret) === ret ? ret : instance;
@@ -936,7 +936,11 @@ class Proxy {
     switch (result[0]) {
       case 'return': return _deserialize(result[1]);
       case 'throws': throw _deserialize(result[1]);
-      case 'none': throw new NoSuchMethodError(receiver, member, args, {});
+      case 'none':
+        if (kind == 'get') {
+          return null;
+        }
+        throw new NoSuchMethodError(receiver, member, args, {});
       default: throw 'Invalid return value';
     }
   }

--- a/test/browser_tests.dart
+++ b/test/browser_tests.dart
@@ -21,7 +21,8 @@ main() {
     js.scoped(() {
       expect(js.context.x, equals(42));
       expect(js.context['x'], equals(42));
-      expect(() => js.context.y, throwsA(isNoSuchMethodError));
+      expect(js.context.y, isNull);
+      expect(() => js.context.y(), throwsA(isNoSuchMethodError));
     });
   });
 


### PR DESCRIPTION
This makes it so getting properties which do not exist return null. This allows checking for existence of properties without exceptions being thrown.
