### PR TITLE
Fixed Proxy when field/variable starts with _

### DIFF
--- a/lib/js.dart
+++ b/lib/js.dart
@@ -918,6 +918,13 @@ class Proxy implements Serializable<Proxy> {
   // Forward member accesses to the backing JavaScript object.
   noSuchMethod(InvocationMirror invocation) {
     String member = invocation.memberName;
+    // If trying to access a JavaScript field/variable that starts with
+    // _ (underscore), Dart treats it a library private and member name
+    // it suffixed with '@internalLibraryIdentifier' which we have to
+    // strip before sending over to the JS side.
+    if (member.indexOf('@') != -1) {
+      member = member.substring(0, member.indexOf('@'));
+    }
     String kind;
     List args = invocation.positionalArguments;
     if (args == null) args = [];


### PR DESCRIPTION
If trying to access a JavaScript field/variable that starts with _ (underscore), Dart treats it as library private and member name is suffixed with '@internalLibraryIdentifier' which we have to strip before sending over to the JS side.
