### PR TITLE
make 'js' depend on 'browser'

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,6 @@ environment:
   sdk: '>=0.4.1+0.r19425'
 dependencies:
   meta: any
+  browser: any
 dev_dependencies:
   unittest: any
-  browser: any


### PR DESCRIPTION
The JS interop depends on the dart.js file from the 'browser' package.
Therefore, moving 'browser' from dev_dependencies to dependencies.
