### PR TITLE
Can't call JavaScript toString() method using js.Proxy object

### DIFF
--- a/lib/js.dart
+++ b/lib/js.dart
@@ -977,6 +977,14 @@ class Proxy implements Serializable<Proxy> {
       : (other is Proxy &&
          _jsPortEquals.callSync([_serialize(this), _serialize(other)]));
 
+  String toString() {
+    try {
+      return _forward(this, 'toString', 'method', []);
+    } catch(e) {
+      return super.toString();
+    }
+  }
+
   // Forward member accesses to the backing JavaScript object.
   noSuchMethod(InvocationMirror invocation) {
     String member = invocation.memberName;

--- a/test/js/browser_tests.dart
+++ b/test/js/browser_tests.dart
@@ -182,6 +182,13 @@ main() {
     expect(() => foo.baz(), throwsA(isNoSuchMethodError));
   });
 
+  test('call toString()', () {
+    var foo = new js.Proxy(js.context.Foo, 42);
+    expect(foo.toString(), equals("I'm a Foo a=42"));
+    var container = js.context.container;
+    expect(container.toString(), equals("[object Object]"));
+  });
+
   test('allocate simple JS array', () {
     final list = [1, 2, 3, 4, 5, 6, 7, 8];
     var array = js.array(list);

--- a/test/js/browser_tests_bootstrap.js
+++ b/test/js/browser_tests_bootstrap.js
@@ -38,6 +38,9 @@ Foo.b = 38;
 Foo.prototype.bar = function() {
   return this.a;
 }
+Foo.prototype.toString = function() {
+  return "I'm a Foo a=" + this.a;
+}
 
 var container = new Object();
 container.Foo = Foo;


### PR DESCRIPTION
From a hackathon:

Can't call JavaScript toString() method using js.Proxy object

Workaround: in JavaScript:
  obj.getString = obj.toString
