### PR TITLE
support for retaining FunctionProxy

### DIFF
--- a/lib/dart_interop.js
+++ b/lib/dart_interop.js
@@ -138,7 +138,6 @@
     delete this.globalIds[id];
     delete this.map[id];
     this._deletedCount++;
-    return old;
   }
 
   // Gets the object or function corresponding to this ID.
@@ -567,13 +566,11 @@
   makeGlobalPort('dart-js-enter-scope', enterJavaScriptScope);
   makeGlobalPort('dart-js-exit-scope', exitJavaScriptScope);
   makeGlobalPort('dart-js-globalize', function(data) {
-    if (data[0] == "objref") return proxiedObjectTable.globalize(data[1]);
-    // TODO(vsm): Do we ever need to globalize functions?
+    if (data[0] == "objref" || data[0] == "funcref") return proxiedObjectTable.globalize(data[1]);
     throw 'Illegal type: ' + data[0];
   });
   makeGlobalPort('dart-js-invalidate', function(data) {
-    if (data[0] == "objref") return proxiedObjectTable.invalidate(data[1]);
-    // TODO(vsm): Do we ever need to globalize functions?
+    if (data[0] == "objref" || data[0] == "funcref") return proxiedObjectTable.invalidate(data[1]);
     throw 'Illegal type: ' + data[0];
   });
 })();

--- a/lib/js.dart
+++ b/lib/js.dart
@@ -215,7 +215,6 @@ final _JS_BOOTSTRAP = r"""
     delete this.globalIds[id];
     delete this.map[id];
     this._deletedCount++;
-    return old;
   }
 
   // Gets the object or function corresponding to this ID.
@@ -644,13 +643,11 @@ final _JS_BOOTSTRAP = r"""
   makeGlobalPort('dart-js-enter-scope', enterJavaScriptScope);
   makeGlobalPort('dart-js-exit-scope', exitJavaScriptScope);
   makeGlobalPort('dart-js-globalize', function(data) {
-    if (data[0] == "objref") return proxiedObjectTable.globalize(data[1]);
-    // TODO(vsm): Do we ever need to globalize functions?
+    if (data[0] == "objref" || data[0] == "funcref") return proxiedObjectTable.globalize(data[1]);
     throw 'Illegal type: ' + data[0];
   });
   makeGlobalPort('dart-js-invalidate', function(data) {
-    if (data[0] == "objref") return proxiedObjectTable.invalidate(data[1]);
-    // TODO(vsm): Do we ever need to globalize functions?
+    if (data[0] == "objref" || data[0] == "funcref") return proxiedObjectTable.invalidate(data[1]);
     throw 'Illegal type: ' + data[0];
   });
 })();

--- a/test/js/browser_tests.dart
+++ b/test/js/browser_tests.dart
@@ -333,6 +333,18 @@ main() {
     });
   });
 
+  test('retain and release a function', () {
+    var razzle;
+    js.scoped(() {
+      razzle = js.retain(js.context.razzle);
+    });
+    js.scoped(() {
+      expect(razzle(), 42);
+      js.release(razzle);
+      expect(() => razzle(), throws);
+    });
+  });
+
   test('pass unattached Dom Element', () {
     final div = new DivElement();
     div.classes.add('a');


### PR DESCRIPTION
It appears that retaining a FunctionProxy instance is not supported.  It is important in order to receive, retain, and later execute, callbacks from Javascript.

e.g. The dart code for a proxy that is called from javascript has a callback as an argument may look like this:

```
void callBackToDartCode(String query, js.FunctionProxy completionCallback) {
  js.retain(completionCallback);   /// THROWS "illegal type: funcref"
  doSomethingAsync(query).then(
    (result) {
       // pass the query result back to the javascript code
       completionCallback(js.map(result));
       // completionCallback is no longer used
       js.release(completionCallback);
  });
}
```

The call to js.retain(completionCallback) will throw an exception "Illegal type: funcref".

Note that the following work around exists, but is an inelegant solution:

```
void callBackToDartCode(String query, js.FunctionProxy completionCallback) {
  js.context.completionCallback = completionCallback;
  doSomethingAsync(query).then(
    (result) {
       // pass the query result back to the javascript code
       js.context.completionCallback(js.map(result));
  });
}
```
