### PR TITLE
FunctionProxy dart->javascript->dart round trip type error

### DIFF
--- a/lib/dart_interop.js
+++ b/lib/dart_interop.js
@@ -316,17 +316,9 @@
                proxiedObjectTable.add(message),
                proxiedObjectTable.sendPort ];
     } else if (typeof(message) == 'function') {
-      if ('_dart_id' in message) {
-        // Remote function proxy.
-        var remoteId = message._dart_id;
-        var remoteSendPort = message._dart_port;
-        return [ 'funcref', remoteId, remoteSendPort ];
-      } else {
-        // Local function proxy.
-        return [ 'funcref',
-                 proxiedObjectTable.add(message),
-                 proxiedObjectTable.sendPort ];
-      }
+      return [ 'funcref',
+               proxiedObjectTable.add(message),
+               proxiedObjectTable.sendPort ];
     } else if (message instanceof DartProxy) {
       // Remote object proxy.
       return [ 'objref', message.id, message.port ];
@@ -382,9 +374,6 @@
           exitScope(depth);
         }
       };
-      // Cache the remote id and port.
-      f._dart_id = id;
-      f._dart_port = port;
       return f;
     }
   }

--- a/lib/js.dart
+++ b/lib/js.dart
@@ -393,17 +393,9 @@ final _JS_BOOTSTRAP = r"""
                proxiedObjectTable.add(message),
                proxiedObjectTable.sendPort ];
     } else if (typeof(message) == 'function') {
-      if ('_dart_id' in message) {
-        // Remote function proxy.
-        var remoteId = message._dart_id;
-        var remoteSendPort = message._dart_port;
-        return [ 'funcref', remoteId, remoteSendPort ];
-      } else {
-        // Local function proxy.
-        return [ 'funcref',
-                 proxiedObjectTable.add(message),
-                 proxiedObjectTable.sendPort ];
-      }
+      return [ 'funcref',
+               proxiedObjectTable.add(message),
+               proxiedObjectTable.sendPort ];
     } else if (message instanceof DartProxy) {
       // Remote object proxy.
       return [ 'objref', message.id, message.port ];
@@ -459,9 +451,6 @@ final _JS_BOOTSTRAP = r"""
           exitScope(depth);
         }
       };
-      // Cache the remote id and port.
-      f._dart_id = id;
-      f._dart_port = port;
       return f;
     }
   }

--- a/test/js/browser_tests.dart
+++ b/test/js/browser_tests.dart
@@ -246,6 +246,13 @@ main() {
     expect(() => js.context.invokeCallback(), throws);
   });
 
+  test('invoke Dart callback from Dart', () {
+    js.context.myFunction = new js.Callback.once((js.FunctionProxy callback) =>
+        callback("test"));
+    expect(js.context.myFunction(
+        new js.Callback.once((String s) => s.toUpperCase())), equals("TEST"));
+  });
+
   test('callback as parameter', () {
     expect(js.context.getTypeOf(js.context.razzle), equals("function"));
   });


### PR DESCRIPTION
I have a Dart function that receives calls from Javascript. The call are initiated in Javascript and include a callback. The dart function looks like this, e.g:

``` dart
void dartFuncCalledFromJS(var anArg, js.FunctionProxy callback) {
  callback(aResult);
}
```

That works fine if I initiate the call from javascript, including the callback.

I attempted to write a unit that to verify, from Dart, the operation of this code.  This means that rather the normal call origination which is Javascript, the call to "dartFuncCalledFromJS" originates in a Dart unit test. From Dart, I can call "myFuncCalledFromJS" as follows:

``` dart
callback(var result) { print("$result"); }
js.context.dartFuncCalledFromJS("aValue", new js.Callback.once(callback).toJs());
```

Note - the toJs() is optional, it runs the same with or without it. I added it so that I explicitly use a a type that matches the declaration of "dartFuncFromJS". 

In this case, the call to "dartFuncCalledFromJS" will fail due to a type mismatch error.  Keep in mind, that it works fine when the call originals from Javascript. The VM error is:

> type '(List) => dynamic' is not a subtype of type 'FunctionProxy' of 'cb'

In the Dart debugger the callback type that I see in dartFuncCalledFromJS is:

> Closure: (dynamic, List) => dynamic  when called via dart->javascript->dart, fails
> but is ....
> js.FunctionProxy when called via javascript->dart, works

In the js-interop code it looked like a serialization problem related to the unusual round tripping of the FunctionProxy that is happening here.
