### PR TITLE
operator==, no hashcode

### DIFF
--- a/lib/js.dart
+++ b/lib/js.dart
@@ -989,6 +989,8 @@ class Proxy implements Serializable<Proxy> {
       : (other is Proxy &&
          _jsPortEquals.callSync([_serialize(this), _serialize(other)]));
 
+  int get hashCode => 0;
+
   String toString() {
     try {
       return _forward(this, 'toString', 'method', []);
@@ -1249,7 +1251,6 @@ _deserialize(var message) {
       return new Proxy._internal(port, id);
     }
   }
-
 
   if (message == null) {
     return null;  // Convert undefined to null.

--- a/test/js/browser_tests.dart
+++ b/test/js/browser_tests.dart
@@ -149,6 +149,13 @@ main() {
     }
   });
 
+  test('hashCode and equals', () {
+    final o1 = js.context.Object;
+    final o2 = js.context.Object;
+    expect(o1 == o2, isTrue);
+    expect(o1.hashCode == o2.hashCode, isTrue);
+  });
+
   test('write global field', () {
     js.context.y = 42;
     expect(js.context.y, equals(42));


### PR DESCRIPTION
Getting warnings from dart2js as of Dart SDK version 0.1.2.0_r24721

packages/js/js.dart:987:11: Hint: The class "Proxy" overrides "operator==", but not "get hashCode".
  operator==(other) => identical(this, other)

There are a few cases.
