### PR TITLE
provide a way to handle elements in ShadowDom

### DIFF
--- a/lib/dart_interop.js
+++ b/lib/dart_interop.js
@@ -207,6 +207,7 @@
   var _localNextElementId = 0;
   var _DART_ID = 'data-dart_id';
   var _DART_TEMPORARY_ATTACHED = 'data-dart_temporary_attached';
+  var _DART_TEMPORARY_ATTACHED_SHADOW = 'data-dart_temporary_attached_shadow_';
 
   function serializeElement(e) {
     // TODO(vsm): Use an isolate-specific id.
@@ -233,34 +234,87 @@
           top.setAttribute(_DART_TEMPORARY_ATTACHED, newValue);
           break;
         }
-        if (top.parentNode == null) {
+        if ((typeof(ShadowRoot) !== "undefined" && 
+            top.parentNode instanceof ShadowRoot) ||
+            (typeof(WebKitShadowRoot) !== "undefined" && 
+            top.parentNode instanceof WebKitShadowRoot)) {
+          var host = top.parentNode.host;
+          if (host !== null) {
+            var shadowId = _DART_TEMPORARY_ATTACHED_SHADOW + id;
+            host.setAttribute(shadowId, '');
+            top = host;
+            continue;
+          } else {
+            throw 'ShadowRoot must have a "host" attribute ' +
+                'to be transfered between Dart and Js';
+          }
+        }
+        if (top.parentElement == null) {
           top.setAttribute(_DART_TEMPORARY_ATTACHED, "a");
           document.documentElement.appendChild(top);
           break;
         }
-        if (top.parentNode === document.documentElement) {
+        if (top.parentElement === document.documentElement) {
           // e was already attached to dom
           break;
         }
-        top = top.parentNode;
+        top = top.parentElement;
       }
     }
     return id;
   }
 
   function deserializeElement(id) {
-    // TODO(vsm): Clear the attribute.
-    var list = document.querySelectorAll('[' + _DART_ID + '="' + id + '"]');
-
-    if (list.length > 1) throw 'Non unique ID: ' + id;
-    if (list.length == 0) {
+    var e = deserializeElementDeep(id);
+    if (e == null) {
       throw 'Element must be attached to the document: ' + id;
     }
-    var e = list[0];
+    return e;
+  }
+  function deserializeElementDeep(id, shadowRoot) {
+    var list;
+    var target;
+    var e;
+    if (!shadowRoot) {
+      list = document.querySelectorAll('[' + _DART_ID + '="' + id + '"]');
+    } else {
+      list = shadowRoot.querySelectorAll('[' + _DART_ID + '="' + id + '"]');
+    }
+    if (list.length > 1) throw 'Non unique ID: ' + id;
+    if (list.length === 1) {
+      target = e = list[0];
+    } else {
+      // looking into shadow nodes
+      var shadowId = _DART_TEMPORARY_ATTACHED_SHADOW + id;
+      var hosts;
+      if (shadowRoot == null) {
+        hosts = document.querySelectorAll('[' + shadowId + ']');
+      } else {
+        hosts = shadowRoot.querySelectorAll('[' + shadowId + ']');
+      }
+      for (var i in hosts) {
+        var host = hosts[i];
+        var hostShadowRoot = (host.shadowRoot || host.webkitShadowRoot);
+        // register host to have the most registrations
+        hostShadowRoot.host = host;
+        // find element in this sub-tree
+        target = deserializeElementDeep(id, hostShadowRoot);
+        if (target != null) {
+          host.removeAttribute(shadowId);
+          if (shadowRoot == null) {
+            e = host;
+            break;
+          } else {
+            return target;
+          }
+        }
+      }
+    }
+
     if (e !== document.documentElement) {
       // detach temporary attached element
       var top = e;
-      while (true) {
+      while (top !== null) {
         if (top.hasAttribute(_DART_TEMPORARY_ATTACHED)) {
           var oldValue = top.getAttribute(_DART_TEMPORARY_ATTACHED);
           var newValue = oldValue.substring(1);
@@ -272,14 +326,14 @@
           }
           break;
         }
-        if (top.parentNode === document.documentElement) {
+        if (top.parentElement === document.documentElement) {
           // e was already attached to dom
           break;
         }
-        top = top.parentNode;
+        top = top.parentElement;
       }
     }
-    return e;
+    return target;
   }
 
 

--- a/test/js/browser_tests.dart
+++ b/test/js/browser_tests.dart
@@ -519,4 +519,25 @@ main() {
     // cleared first.
     runAsync(verifyNoLeaks);
   });
+
+  group('shadowDom', (){
+    if (!js.context.ShadowTest.isShadowAvailable()) return;
+
+    test('Dart to Js', (){
+      final host = new Element.div();
+      final root = host.createShadowRoot();
+      js.registerHost(root, host);
+      root.innerHtml = "<b>Dart is awesome !</b>";
+      js.context.ShadowTest.modifyText(host.shadowRoot.query("b"));
+      expect(root.firstChild.text, equals("Dart is awesome ! (hacked by JS)"));
+    });
+
+    test('Js to Dart', (){
+      bool result = js.context.ShadowTest.testJsToDart(
+          new js.Callback.once((Element e) {
+            e.text = e.text + " (hacked by Dart)";
+          }));
+      expect(result, isTrue);
+    });
+  });
 }

--- a/test/js/browser_tests_bootstrap.js
+++ b/test/js/browser_tests_bootstrap.js
@@ -97,3 +97,24 @@ function Bar() {
   return "ret_value";
 }
 Bar.foo = "property_value";
+
+// shadowRoot tests
+ShadowTest = {};
+
+ShadowTest.isShadowAvailable = function() {
+  return typeof(WebKitShadowRoot) != "undefined" ||
+      typeof(ShadowRoot) != "undefined";
+}
+
+ShadowTest.modifyText = function(e){
+  return e.innerText = e.innerText + " (hacked by JS)";
+}
+
+ShadowTest.testJsToDart = function(fn){
+  var host = document.createElement('div');
+  var root = host.webkitCreateShadowRoot();
+  root.host = host;
+  root.innerHTML = "<b>JS is awesome !</b>";
+  fn(root.querySelector('b'));
+  return root.firstChild.innerText === "JS is awesome ! (hacked by Dart)";
+}


### PR DESCRIPTION
Basically you have to bind all the `host`s of the `ShadowRoot`s to make `Element`s transferable (even in `ShadowRoot`). In Dart by calling `js.registerHost(root, host)` and in JS with `root.host = host`.
