### PR TITLE
updated browser_test.html files to use test_controller.js

### DIFF
--- a/test/js/browser_tests.html
+++ b/test/js/browser_tests.html
@@ -17,14 +17,10 @@
     .test-area { display: none; }
     body { overflow: visible; }
   </style>
-  <!-- This script comes from running "pub install" in the root folder. -->
-  <!-- disabled because of http://dartbug.com/4943
-  <script type="text/javascript" src="../packages/unittest/test_controller.js">
-  </script>
-  -->
 </head>
 <body>
   <h1>Loading and running tests</h1>
+  <script src="packages/unittest/test_controller.js"></script>
   <script type="application/dart" src="browser_tests.dart"></script>
   <script src="browser_tests_bootstrap.js"></script>
   <script src="packages/browser/dart.js"></script>

--- a/test/js_wrapping/browser_tests.html
+++ b/test/js_wrapping/browser_tests.html
@@ -25,6 +25,7 @@ function Person(firstname, lastname){
 Person.prototype.sayHello = function() { return "Hello, I'm " + this.firstname + " " + this.lastname; };
 
 </script>
+  <script src="packages/unittest/test_controller.js"></script>
   <script type="application/dart" src="browser_tests.dart"></script>
   <script src="packages/browser/dart.js"></script>
   <script src="packages/browser/interop.js"></script>


### PR DESCRIPTION
Both browser test files now run via `content_shell --dump-render-tree` without a problem
