### PR TITLE
Adding MirrorsUsed attribute to dart:mirrors import

### DIFF
--- a/lib/js.dart
+++ b/lib/js.dart
@@ -70,6 +70,7 @@
 library js;
 
 import 'dart:js' as js;
+@MirrorsUsed(symbols: '*')
 import 'dart:mirrors';
 
 /**


### PR DESCRIPTION
It's only using symbols, so just enabling that. For the unittests, this takes the size from ~4.5MB down to ~670kB.
