### PR TITLE
Mirrors used

### DIFF
--- a/lib/js.dart
+++ b/lib/js.dart
@@ -70,7 +70,6 @@
 library js;
 
 import 'dart:js' as js;
-@MirrorsUsed(symbols: '*')
 import 'dart:mirrors';
 
 /**

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: js
-version: 0.2.1
+version: 0.2.2
 authors:
 - Dart Team <misc@dartlang.org>
 - Alexandre Ardhuin <alexandre.ardhuin@gmail.com>


### PR DESCRIPTION
The current @MirrorsUsed annotation is broken. `symbols: '*'` preserves the multiplication operation, not all symbols. This breaks apps under minification, since the symbols for the methods they invoke are not preserved. I think it's better to remove the annotation for now, so that apps work after minification.
