### PR TITLE
allow JsObject in toDart/toJs

### DIFF
--- a/lib/src/js_impl.dart
+++ b/lib/src/js_impl.dart
@@ -53,7 +53,8 @@ bool isGlobal(JsInterface o) => o is JsGlobal;
  */
 dynamic toJs(dynamic o) {
   if (o == null) return o;
-  if (o is num || o is String || o is bool || o is DateTime) return o;
+  if (o is num || o is String || o is bool || o is DateTime
+      || o is JsObject) return o;
 
   if (o is JsInterface) return  o._jsObject;
   var type = o.runtimeType;
@@ -114,6 +115,8 @@ dynamic toDart(dynamic o, [Symbol fallbackType]) {
     if (fallbackType == #Map) {
       return new JsObjectMap.fromJsObject(o);
     }
+
+    return o;
   }
   throw new ArgumentError("Could not convert ${o.runtimeType}($o) to Dart");
 }

--- a/test_sources/non_transformed/lib/library.dart
+++ b/test_sources/non_transformed/lib/library.dart
@@ -99,6 +99,10 @@ abstract class JsFoo extends JsInterface implements HasName {
 
   String getName(HasName b);
 
+  JsObject getAnonymous();
+
+  void setAnonymous(JsObject o);
+
   void setBar(JsBar);
 
   JsBar get bar;

--- a/test_sources/non_transformed/lib/library.js
+++ b/test_sources/non_transformed/lib/library.js
@@ -12,6 +12,7 @@ var a = null;
 function JsThing(name) {
   this.name = name;
   this.bar = null;
+  this.anonymous = {a:1,b:2};
 }
 
 JsThing.prototype.double = function(x) {
@@ -20,6 +21,14 @@ JsThing.prototype.double = function(x) {
 
 JsThing.prototype.getName = function(o) {
   return o.name;
+}
+
+JsThing.prototype.getAnonymous = function() {
+  return this.anonymous;
+}
+
+JsThing.prototype.setAnonymous = function(o) {
+  this.anonymous = o;
 }
 
 JsThing.prototype.setBar = function(bar) {

--- a/test_sources/non_transformed/web/generated_code_test.dart
+++ b/test_sources/non_transformed/web/generated_code_test.dart
@@ -124,6 +124,18 @@ main() {
       expect(name, 'blue');
     });
 
+    test('should allow to return JsObject', () {
+      var foo = new t.JsFoo('red');
+      var o = foo.getAnonymous();
+      expect(o, toJs(foo)['anonymous']);
+    });
+
+    test('should allow to use JsObject as argument', () {
+      var foo = new t.JsFoo('');
+      foo.setAnonymous(new js.JsObject.jsify({'a': 3}));
+      expect(toJs(foo)['anonymous']['a'], 3);
+    });
+
     test('should return proxy values', () {
       var foo = new t.JsFoo('red');
       var bar = new t.JsBar('blue');


### PR DESCRIPTION
This allows to retrieve anonymous js object returned by a method. `registerFactoryForJsConstructor` cannot be used in that case.
This also can be used as a workaround to use List in parameters (once `@JsName` has landed).

I submitted the same PR ( #165 ) but it seems to have been destroyed by the branch renaming.

If the close was wanted, could you tell me why please ?
