### PR TITLE
add a command to generate proxy template

### DIFF
--- a/bin/new_proxies.dart
+++ b/bin/new_proxies.dart
@@ -1,0 +1,12 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:js/proxy_creator.dart';
+
+main(List<String> args) {
+  if (args.isEmpty) {
+    print('You must provide one or more class names as arguments');
+  }
+  print(args.map(createProxySkeleton).join('\n\n'));
+}

--- a/lib/proxy_creator.dart
+++ b/lib/proxy_creator.dart
@@ -1,0 +1,22 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library js.proxy_creator;
+
+String createProxySkeleton(String name) {
+  final className = name.substring(name.lastIndexOf('.') + 1);
+  final implClassName = className + 'Impl';
+  return '''
+abstract class $className extends JsInterface {
+  factory $className() => new $implClassName();
+  $className.created(JsObject o) : super.created(o);
+}
+
+@JsProxy(constructor: '$name')
+class $implClassName extends $className {
+  factory $implClassName() => new JsInterface($implClassName, []);
+  $implClassName.created(JsObject o) : super.created(o);
+  noSuchMethod(i) => super.noSuchMethod(i);
+}''';
+}

--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -6,8 +6,10 @@ library js.test.all_tests;
 
 import 'transformer/all_tests.dart' as transformer;
 import 'js_elements_test.dart' as js_elements;
+import 'proxy_creator_test.dart' as proxy_creator;
 
 main() {
   js_elements.main();
   transformer.main();
+  proxy_creator.main();
 }

--- a/test/proxy_creator_test.dart
+++ b/test/proxy_creator_test.dart
@@ -1,0 +1,44 @@
+// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+library js.test.proxy_creator_test;
+
+import 'package:unittest/unittest.dart';
+import 'package:js/proxy_creator.dart';
+
+main() {
+  group('Proxy creation', () {
+
+    test('should accept simple name', () {
+      expect(createProxySkeleton('MyClass'), '''
+abstract class MyClass extends JsInterface {
+  factory MyClass() => new MyClassImpl();
+  MyClass.created(JsObject o) : super.created(o);
+}
+
+@JsProxy(constructor: 'MyClass')
+class MyClassImpl extends MyClass {
+  factory MyClassImpl() => new JsInterface(MyClassImpl, []);
+  MyClassImpl.created(JsObject o) : super.created(o);
+  noSuchMethod(i) => super.noSuchMethod(i);
+}''');
+    });
+
+    test('should accept qualified name', () {
+      expect(createProxySkeleton('a.b.MyClass'), '''
+abstract class MyClass extends JsInterface {
+  factory MyClass() => new MyClassImpl();
+  MyClass.created(JsObject o) : super.created(o);
+}
+
+@JsProxy(constructor: 'a.b.MyClass')
+class MyClassImpl extends MyClass {
+  factory MyClassImpl() => new JsInterface(MyClassImpl, []);
+  MyClassImpl.created(JsObject o) : super.created(o);
+  noSuchMethod(i) => super.noSuchMethod(i);
+}''');
+    });
+
+  });
+}


### PR DESCRIPTION
`pub run new_proxies a.b.MyClass MyClass2` will generate in the console output :

``` dart
abstract class MyClass extends JsInterface {
  factory MyClass() => new MyClassImpl();
  MyClass.created(JsObject o) : super.created(o);
}

@JsProxy(constructor: 'a.b.MyClass')
class MyClassImpl extends MyClass {
  factory MyClassImpl() => new JsInterface(MyClassImpl, []);
  MyClassImpl.created(JsObject o) : super.created(o);
  noSuchMethod(i) => super.noSuchMethod(i);
}

abstract class MyClass2 extends JsInterface {
  factory MyClass2() => new MyClass2Impl();
  MyClass2.created(JsObject o) : super.created(o);
}

@JsProxy(constructor: 'MyClass2')
class MyClass2Impl extends MyClass2 {
  factory MyClass2Impl() => new JsInterface(MyClass2Impl, []);
  MyClass2Impl.created(JsObject o) : super.created(o);
  noSuchMethod(i) => super.noSuchMethod(i);
}
```
