### PR TITLE
Handle interfaces and mixin

### DIFF
--- a/lib/src/transformer/js_proxy_generator.dart
+++ b/lib/src/transformer/js_proxy_generator.dart
@@ -11,7 +11,6 @@ import 'package:barback/barback.dart';
 import 'package:js/src/metadata.dart';
 import 'package:js/src/transformer/utils.dart';
 import 'package:logging/logging.dart';
-import 'package:quiver/iterables.dart' show max, concat;
 import 'package:source_maps/refactor.dart';
 
 final _logger = new Logger('js.transformer.js_proxy_generator');
@@ -35,7 +34,7 @@ class JsProxyGenerator {
   final Iterable<ClassElement> jsProxies;
   final InheritanceManager inheritanceManager;
 
-  var generatedMembers = new Set<Element>();
+  final generatedMembers = <ClassElement, Set<Element>>{};
 
   JsProxyGenerator(
     this.inputId,
@@ -176,28 +175,28 @@ class JsProxyGenerator {
       var memberKey = memberMap.getKey(i);
       var member = memberMap.getValue(i);
 
-      if (generatedMembers.contains(member) || !member.isAbstract) continue;
-      generatedMembers.add(member);
+      var createSet = () => new Set<ClassElement>();
+      if (generatedMembers.putIfAbsent(proxy, createSet).contains(member) ||
+          (!member.isAbstract && !member.isSynthetic)) continue;
+      generatedMembers[proxy].add(member);
+
 
       if (member is PropertyAccessorElement) {
         if (member.isGetter) {
-          _generateGetter(member);
+          _generateGetter(proxy, member);
         } else if (member.isSetter) {
-          _generateSetter(member);
+          _generateSetter(proxy, member);
         }
       } else if (member is MethodElement) {
-        _generateMethod(member);
+        _generateMethod(proxy, member);
       }
     }
-
   }
 
-  void _generateMethod(MethodElement a) {
+  void _generateMethod(ClassElement proxy, MethodElement a) {
     var nameAnnotation = getNameAnnotation(a.node, jsNameClass);
     var name = nameAnnotation == null ? a.displayName : nameAnnotation.name;
     if (!a.isStatic) {
-      var returnType = a.returnType;
-
       var jsArgs = new List(a.parameters.length);
 
       for (int i = 0; i < a.parameters.length; i++) {
@@ -212,50 +211,82 @@ class JsProxyGenerator {
 
       var parameterList = jsArgs.join(', ');
 
-      MethodDeclaration m = a.node;
-      var offset = m.body.offset;
-      var end = m.body.end;
-      if (a.returnType.name == 'void') {
-        transaction.edit(offset, end, " { $JS_PREFIX.toDart("
-            "$JS_PREFIX.toJs(this).callMethod('$name', [$parameterList])); }");
+      var getContent = (DartType returnType, String name, String paramList) {
+        var jsCall = "$JS_PREFIX.toJs(this).callMethod('$name', [$paramList])";
+        return returnType.isVoid ? ' { $jsCall; }' :
+            ' => $JS_PREFIX.toDart($jsCall, #${returnType.name})'
+            ' as ${returnType};';
+      };
+
+      if (a.isSynthetic || a.enclosingElement != proxy) {
+        var offset = proxy.node.end - 1;
+        var source = a.node.toSource();
+        source = source.substring(0, source.length - 1);
+        transaction.edit(offset, offset,
+            '  $source${getContent(a.returnType, name, parameterList)}\n');
       } else {
-        transaction.edit(offset, end, " => $JS_PREFIX.toDart("
-            "$JS_PREFIX.toJs(this).callMethod('$name', [$parameterList]), "
-            "#${returnType.name}) as ${a.returnType};");
+        MethodDeclaration m = a.node;
+        var offset = m.body.offset;
+        var end = m.body.end;
+        transaction.edit(offset, end,
+            getContent(a.returnType, name, parameterList));
       }
     }
   }
 
-  void _generateSetter(PropertyAccessorElement a) {
+  void _generateSetter(ClassElement proxy, PropertyAccessorElement a) {
     var parameter = a.parameters.single;
     var type = parameter.type;
     if (type == null) {
       _logger.severe("abstract JsInterface setters must have type annotations");
       return;
     }
+
+    var nameAnnotation = getNameAnnotation(a.isSynthetic ?
+        a.variable.node.parent.parent : a.node, jsNameClass);
+    var name = nameAnnotation != null ? nameAnnotation.name : a.displayName;
+
+    var getContent = (String name, String parameterName) =>
+        " { $JS_PREFIX.toJs(this)['$name'] = $JS_PREFIX.toJs($parameterName); }";
+
     var parameterName = parameter.name;
-    MethodDeclaration m = a.node;
-    var nameAnnotation = getNameAnnotation(m, jsNameClass);
-    var name = nameAnnotation == null ? a.displayName : nameAnnotation.name;
-    var offset = m.body.offset;
-    var end = m.body.end;
-    transaction.edit(offset, end, " { $JS_PREFIX.toJs(this)['$name']"
-        " = $JS_PREFIX.toJs($parameterName); }");
+    if (a.isSynthetic || a.enclosingElement != proxy) {
+      var offset = proxy.node.end - 1;
+      transaction.edit(offset, offset,
+          '  void set ${a.displayName}($type $parameterName)'
+          '${getContent(name, parameterName)}\n');
+    } else {
+      MethodDeclaration m = a.node;
+      var offset = m.body.offset;
+      var end = m.body.end;
+      transaction.edit(offset, end, getContent(name, parameterName));
+    }
   }
 
-  void _generateGetter(PropertyAccessorElement a) {
+  void _generateGetter(ClassElement proxy, PropertyAccessorElement a) {
     var type = a.type.returnType;
     if (type == null) {
       _logger.severe("abstract JsInterface getters must have type annotations");
       return;
     }
-    MethodDeclaration m = a.node;
-    var nameAnnotation = getNameAnnotation(m, jsNameClass);
-    var name = nameAnnotation == null ? a.displayName : nameAnnotation.name;
-    var offset = m.body.offset;
-    var end = m.body.end;
-    transaction.edit(offset, end, " => $JS_PREFIX.toDart("
-        "$JS_PREFIX.toJs(this)['$name']) as $type;");
+
+    var nameAnnotation = getNameAnnotation(a.isSynthetic ?
+        a.variable.node.parent.parent : a.node, jsNameClass);
+    var name = nameAnnotation != null ? nameAnnotation.name : a.displayName;
+
+    var getContent = (String name, DartType type) =>
+        " => $JS_PREFIX.toDart($JS_PREFIX.toJs(this)['$name']) as $type;";
+
+    if (a.isSynthetic || a.enclosingElement != proxy) {
+      var offset = proxy.node.end - 1;
+      transaction.edit(offset, offset, "  ${a.returnType} get ${a.displayName}"
+          "${getContent(name, a.returnType)}\n");
+    } else {
+      MethodDeclaration m = a.node;
+      var offset = m.body.offset;
+      var end = m.body.end;
+      transaction.edit(offset, end, getContent(name, type));
+    }
   }
 
   ConstructorElement _getFactoryConstructor(ClassElement interface) =>

--- a/test_sources/non_transformed/lib/library.dart
+++ b/test_sources/non_transformed/lib/library.dart
@@ -85,17 +85,14 @@ abstract class HasName {
   String name;
 }
 
-abstract class JsFoo extends JsInterface implements HasName {
+abstract class JsFoo extends JsInterface with _JsFooMethod implements HasName,
+    _JsFooProperties {
 
   JsFoo.created(JsObject o) : super.created(o);
 
   factory JsFoo(String name) => new JsFooImpl(name);
 
-  String get name;
-
   int y() => 1;
-
-  num double(num x);
 
   String getName(HasName b);
 
@@ -104,9 +101,14 @@ abstract class JsFoo extends JsInterface implements HasName {
   void setAnonymous(JsObject o);
 
   void setBar(JsBar);
+}
 
-  JsBar get bar;
-  void set bar(JsBar bar);
+abstract class _JsFooProperties {
+  JsBar bar;
+}
+
+abstract class _JsFooMethod {
+  num double(num x);
 }
 
 @JsProxy(constructor: 'JsThing')


### PR DESCRIPTION
This change also allows to simplify properties declaration. For instance :

``` dart
abstract class Person extends JsInterface implements _PersonProperties {
  factory Person(String name) => new PersonImpl(name);
  Person.created(JsObject o) : super.created(o);
}

abstract class _PersonProperties {
  String firstname;
  String lastname;
}

@JsProxy(constructor: 'Person')
class PersonImpl extends Person {
  factory PersonImpl(String name) => new JsInterface(PersonImpl, [name]);
  PersonImpl.created(JsObject o) : super.created(o);
  noSuchMethod(i) => super.noSuchMethod(i);
}
```

BTW the complete implementation of abstract members are now generated on XxxImpl.
